### PR TITLE
Hunter fixes

### DIFF
--- a/packages/vistle/package.py
+++ b/packages/vistle/package.py
@@ -60,6 +60,9 @@ class Vistle(CMakePackage, ROCmPackage, CudaPackage):
     variant('rocm', default=False, description='Use rocm-enabled Kokkos backend for internal VTK-m', when='~vtkm')
     variant('vtkm', default=False, description='Use external copy of VTK-m')
     variant('openmp', default=True, description='Use OpenMP (including within Kokkos)')
+    
+    variant('nvtx', default=False, description='Add annotations for the Nsight profiler')
+    variant('roctx', default=False, description='Add annotations for the ROCm profiler')
 
     conflicts('%gcc@:7')
     depends_on('cmake@3.10:', type='build')
@@ -212,5 +215,8 @@ class Vistle(CMakePackage, ROCmPackage, CudaPackage):
         args.append(self.define_from_variant('VISTLE_64BIT_INDICES', 'large'))
 
         args.append(self.define_from_variant('VISTLE_INSTALL_3RDPARTY', 'dev'))
+
+        args.append(self.define_from_variant('VISTLE_PROFILE_NVTX', 'nvtx'))
+        args.append(self.define_from_variant('VISTLE_PROFILE_ROCTX', 'roctx'))
 
         return args

--- a/packages/vistle/package.py
+++ b/packages/vistle/package.py
@@ -116,7 +116,7 @@ class Vistle(CMakePackage, ROCmPackage, CudaPackage):
         conflicts('+rocm')
         depends_on("kokkos +cuda", when="+kokkos")
 
-    depends_on('netcdf-c +hdf4') # hdf4 for MPAS
+    depends_on('netcdf-c +hdf4', when='+netcdf') # hdf4 for MPAS
     depends_on('netcdf-cxx4', when='+netcdf')
     depends_on('parallel-netcdf', when='+pnetcdf')
     depends_on('hdf5', when='+hdf5')

--- a/packages/vistle/package.py
+++ b/packages/vistle/package.py
@@ -168,6 +168,11 @@ class Vistle(CMakePackage, ROCmPackage, CudaPackage):
         env.set('VISTLE_ROOT', self.prefix)
         if self.spec.satisfies('+python'):
             env.prepend_path("PYTHONPATH", self.prefix.lib)
+    
+    def _define_hip_arch(self):
+        if hasattr(self, "define_hip_architectures"):
+            return self.define_hip_architectures(self)
+        return self.builder.define_hip_architectures(self)
 
     def cmake_args(self):
         """Populate cmake arguments for Vistle."""
@@ -178,6 +183,7 @@ class Vistle(CMakePackage, ROCmPackage, CudaPackage):
         # avoid breaking build
         args.append(self.define('VISTLE_COLOR_DIAGNOSTICS', False))
         args.append(self.define('VISTLE_PEDANTIC_ERRORS', False))
+    
 
         if '+static' in spec:
             args.extend([
@@ -194,7 +200,7 @@ class Vistle(CMakePackage, ROCmPackage, CudaPackage):
 
             # hip support
             if "+rocm" in spec:
-                args.append(self.builder.define_hip_architectures(self))
+                args.append(self._define_hip_arch())
                 if "+kokkos" in spec:
                     hipcc = self.spec['hip'].hipcc
                     args.append(self.define('CMAKE_CXX_COMPILER', str(hipcc)))


### PR DESCRIPTION
- Since netcdf is not buildable on Hunter and the external version does not include the hdf4 variant (as required by Vistle), netcdf was made optional.
- On Hunter, spack was updated to version 1.1.0, where `self.builder.define_hip_architectures` was moved to `self.define_hip_architectures`.

I also added two variants for enabling NVTX and ROCTx markers.